### PR TITLE
Fix `BigInt_multiply` crash

### DIFF
--- a/BigInt.c
+++ b/BigInt.c
@@ -255,7 +255,7 @@ void BigInt_multiply(BigInt* big_int, const BigInt* multiplier) {
     // the multiplication.
     BigInt* addend = BigInt_construct(0);    
 
-    unsigned int digits_needed = big_int->num_digits + addend->num_digits + 1;
+    unsigned int digits_needed = big_int->num_digits + multiplier->num_digits + 1;
     BigInt_ensure_digits(addend, digits_needed);
 
     int i, j;


### PR DESCRIPTION
Found a bug where `BigInt_multiply` could crash due to accessing invalid memory, particularly if the multiplier was large. This change fixes the calculation of the required number of digits.